### PR TITLE
Improve the look of waterfalls

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -103,14 +103,13 @@ end
 
 local function setLevel(pos, level, name, downward)
     local node = get(pos)
-    local pt2 = defs[node.name].paramtype2
+    set(pos, {name = name or node.name, param2 = level})
     if downward then
 	minetest.get_meta(pos):set_int("waterfinity:real_level", level)
 	level = 15
     else
 	minetest.get_meta(pos):set_int("waterfinity:real_level", 0)
     end
-    set(pos, {name = name or node.name, param2 = level})
 end
 
 -- Returns if we can spread to a position based only on what's below it.

--- a/init.lua
+++ b/init.lua
@@ -292,7 +292,7 @@ function waterfinity.register_liquid(liquidDef)
                 local level = getLevel(pos)
                 local def = defs[name] or empty
 
-                if name == flowing and getLevel(pos) < 7 or (def.floodable and spreadable(pos)) then
+                if name == flowing and getLevel(pos) < 7 or def.floodable then
                     set(pos, {name = flowing, param2 = 7})
                     update(pos)
                 end


### PR DESCRIPTION
* Prevent horizontal flow for more than 1 block over a floodable - avoids "pulsing" waterfalls
* Use node metadata for level when flowing downward and set the engine level to 7 - improves look of downward flow
* Set bit 3 of param2 when flowing downward - I have no idea what this does, but the docs say it means "flowing down"
* Various readability improvements, remove some dead code